### PR TITLE
Troubleshoot Farcaster manifest redirection error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "snake-game",
+  "version": "1.0.0",
+  "description": "Feed The Snake - A Farcaster miniapp game",
+  "main": "index.html",
+  "scripts": {
+    "start": "python3 -m http.server 3000",
+    "build": "echo 'No build needed for static site'"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,21 @@
     {
       "source": "/",
       "destination": "/index.html"
+    },
+    {
+      "source": "/index",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/index.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add `package.json` and update `vercel.json` to fix 404 errors by correctly serving `index.html`.

The user was experiencing persistent 404 errors because Vercel was not automatically serving `index.html` as the default page. The `vercel.json` now includes explicit rewrite rules to map the root path (`/`) to `/index.html`, ensuring the game loads correctly. A `package.json` was also added to provide standard project metadata for Vercel.